### PR TITLE
feat(node-versions): dropped support for node v12 since it is close t…

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -28,8 +28,7 @@ jobs:
     strategy:
       matrix:
         node:
-          - 12.18.0
-          - 14
+          - 14.13.1
           - 16
     steps:
       - uses: actions/checkout@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "remark-cli": "10.0.1"
       },
       "engines": {
-        "node": ">12.17"
+        "node": ">=14.13.1"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "exports": "./index.js",
   "engines": {
-    "node": ">12.17"
+    "node": ">=14.13.1"
   },
   "license": "MIT",
   "version": "0.0.0-semantically-released",


### PR DESCRIPTION
…o EOL

BREAKING CHANGE: the lowest supported node version is now v14.13.1