### PR TITLE
feat: align table and bullet formatting with Prettier's output (breaking)

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ export default {
     [remarkLintMaximumLineLength, 80],
     [remarkLintOrderedListMarkerValue, 'one'],
     remarkLintNoEmptyUrl,
-    [remarkLintUnorderedListMarkerStyle, '*'],
+    [remarkLintUnorderedListMarkerStyle, '-'],
     remarkLintTableCellPadding
   ]
 };

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ import remarkLintMaximumLineLength from 'remark-lint-maximum-line-length';
 import remarkLintOrderedListMarkerValue from 'remark-lint-ordered-list-marker-value';
 import remarkLintNoEmptyUrl from 'remark-lint-no-empty-url';
 import remarkLintUnorderedListMarkerStyle from 'remark-lint-unordered-list-marker-style';
+import remarkLintTableCellPadding from 'remark-lint-table-cell-padding';
 import remarkGithubFlavoredMarkdown from 'remark-gfm';
 
 export default {
@@ -20,6 +21,7 @@ export default {
     [remarkLintMaximumLineLength, 80],
     [remarkLintOrderedListMarkerValue, 'one'],
     remarkLintNoEmptyUrl,
-    [remarkLintUnorderedListMarkerStyle, '*']
+    [remarkLintUnorderedListMarkerStyle, '*'],
+    remarkLintTableCellPadding
   ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "remark-lint-no-empty-url": "4.0.1",
         "remark-lint-no-tabs": "4.0.1",
         "remark-lint-ordered-list-marker-value": "4.0.1",
+        "remark-lint-table-cell-padding": "5.1.1",
         "remark-lint-unordered-list-marker-style": "4.0.1",
         "remark-preset-lint-recommended": "7.0.1",
         "remark-validate-links": "13.1.0"
@@ -10979,6 +10980,27 @@
         "devlop": "^1.0.0",
         "mdast-util-phrasing": "^4.0.0",
         "micromark-util-character": "^2.0.0",
+        "unified-lint-rule": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-lint-table-cell-padding": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/remark-lint-table-cell-padding/-/remark-lint-table-cell-padding-5.1.1.tgz",
+      "integrity": "sha512-6fgVA1iINBoAJaZMOnSsxrF9Qj9+hmCqrsrqZqgJJETjT1ODGH64iAN1/6vHR7dIwmy73d6ysB2WrGyKhVlK3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "pluralize": "^8.0.0",
         "unified-lint-rule": "^3.0.0",
         "unist-util-position": "^5.0.0",
         "unist-util-visit-parents": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "remark-lint-no-empty-url": "4.0.1",
     "remark-lint-no-tabs": "4.0.1",
     "remark-lint-ordered-list-marker-value": "4.0.1",
+    "remark-lint-table-cell-padding": "5.1.1",
     "remark-lint-unordered-list-marker-style": "4.0.1",
     "remark-preset-lint-recommended": "7.0.1",
     "remark-validate-links": "13.1.0"


### PR DESCRIPTION
## Summary

Two related, both **breaking**, changes aligning this preset with what
Prettier (used for markdown formatting in
[travi/home-network](https://github.com/travi/home-network) and elsewhere)
actually outputs — both are things Prettier hardcodes with no config
option, so consumers using Prettier were stuck fighting this preset on
every format pass.

### 1. `feat: enforce consistent table cell padding`

Adds [remark-lint-table-cell-padding](https://www.npmjs.com/package/remark-lint-table-cell-padding)
at its default `'consistent'` setting — flags a table that mixes padded
and unpadded rows within itself, which is exactly what an unpadded,
hand-edited `|---|---|`-style table looks like sitting next to Prettier's
padded output.

**Breaking**: any existing table mixing padded/unpadded rows now fails
lint under `--frail`, where it previously passed.

### 2. `feat: switch unordered list bullet marker from '*' to '-'`

Prettier hardcodes `-` for unordered lists, no config to change it. This
preset was still enforcing `*`.

**Breaking**: any existing `*` bullet now fails lint under `--frail`,
where it previously passed.

## Verified (both)

- Violating content (mixed-padding table / `*` bullet) → now fails with
  the corresponding rule's error under `--frail`.
- Prettier-formatted content → passes clean.
- Tested through the actual exported preset (not just each rule in
  isolation) via a throwaway `.remarkrc.js` importing `index.js` directly.
- `npm test` (lint:md, lint:sensitive, lint:engines, lint:publish) passes
  clean with both changes — this repo's own README has no bullets or
  tables to conflict with either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)